### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/scripts/_geoloc_update.sh
+++ b/scripts/_geoloc_update.sh
@@ -26,8 +26,8 @@ rm -rf "/tmp/geoloc.$tok"
 
 # Deprecated as of Jan 2019
 #
-#wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/GeoLiteCity-latest.zip
-#wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip
+#wget https://geolite.maxmind.com/download/geoip/database/GeoLiteCity_CSV/GeoLiteCity-latest.zip
+#wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip
 #
 #blocks_file=$(unzip -l GeoLiteCity-latest.zip |grep City.Blocks.csv | awk '{print $4}')
 #dir=$(dirname $blocks_file)


### PR DESCRIPTION
I see that the relevant code has been deprecated, but I thought I would mention that MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).